### PR TITLE
create online offliine channel

### DIFF
--- a/apps/inventory/filters.py
+++ b/apps/inventory/filters.py
@@ -9,10 +9,19 @@ class ProductVariantFilter(django_filters.FilterSet):
     sales_max = django_filters.NumberFilter(method="filter_sales_max")
     product_name = django_filters.CharFilter(method="filter_product_name")
     category = django_filters.CharFilter(field_name="product__category", lookup_expr="icontains")
+    channel = django_filters.CharFilter(method="filter_channel")
 
     class Meta:
         model = ProductVariant
-        fields = ["stock_lt", "stock_gt", "sales_min", "sales_max", "product_name", "category"]
+        fields = [
+            "stock_lt",
+            "stock_gt",
+            "sales_min",
+            "sales_max",
+            "product_name",
+            "category",
+            "channel",
+        ]
 
     def filter_sales_min(self, queryset, name, value):
         return queryset.annotate(
@@ -32,6 +41,13 @@ class ProductVariantFilter(django_filters.FilterSet):
     
     def filter_product_name(self, queryset, name, value):
             return queryset.filter(product__name__icontains=value)
+
+    def filter_channel(self, queryset, name, value):
+        value = (value or "").strip().lower()
+        if value in ("online", "offline"):
+            # JSONField list containment: channels contains the given value
+            return queryset.filter(channels__contains=[value])
+        return queryset
     
 class InventoryAdjustmentFilter(django_filters.FilterSet):
     variant_code = django_filters.CharFilter(field_name='variant__variant_code', lookup_expr='exact')

--- a/apps/inventory/migrations/0003_productvariant_channels.py
+++ b/apps/inventory/migrations/0003_productvariant_channels.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0002_inventorysnapshot_inventorysnapshotitem"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="productvariant",
+            name="channels",
+            field=models.JSONField(default=list, blank=True),
+        ),
+    ]
+

--- a/apps/inventory/migrations/0004_merge_20250916_1630.py
+++ b/apps/inventory/migrations/0004_merge_20250916_1630.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0003_merge_20250912_1722"),
+        ("inventory", "0003_productvariant_channels"),
+    ]
+
+    operations = []
+

--- a/apps/inventory/models.py
+++ b/apps/inventory/models.py
@@ -51,6 +51,7 @@ class ProductVariant(models.Model):
     order_count = models.PositiveIntegerField(default=0)
     return_count = models.PositiveIntegerField(default=0)
     is_active = models.BooleanField(default=True)
+    channels = models.JSONField(default=list, blank=True)
 
     class Meta:
         db_table = "product_variants"

--- a/apps/inventory/serializers.py
+++ b/apps/inventory/serializers.py
@@ -26,6 +26,7 @@ class ProductVariantSerializer(serializers.ModelSerializer):
     stock = serializers.IntegerField(read_only=True)
     sales = serializers.SerializerMethodField()
     name = serializers.SerializerMethodField()
+    channels = serializers.ListField(child=serializers.CharField(), read_only=True)
 
     class Meta:
         model = ProductVariant
@@ -44,7 +45,8 @@ class ProductVariantSerializer(serializers.ModelSerializer):
             'order_count',          # 판매수량
             'return_count',          # 환불수량
             'sales',
-            'suppliers'             # 공급자명
+            'suppliers',            # 공급자명
+            'channels',             # 온라인/오프라인 태그
         ]
 
     def get_fields(self):

--- a/apps/inventory/views.py
+++ b/apps/inventory/views.py
@@ -432,6 +432,14 @@ class ProductVariantCSVUploadView(APIView):
                         variant.order_count += delta_order
                         variant.return_count += delta_return
                         variant.save()
+                        # 채널 태그: online 추가
+                        if isinstance(variant.channels, list):
+                            if "online" not in variant.channels:
+                                variant.channels.append("online")
+                                variant.save(update_fields=["channels"])
+                        else:
+                            variant.channels = ["online"]
+                            variant.save(update_fields=["channels"])
                         updated.append(ProductVariantSerializer(variant).data)
                     else:
                         self._snapshot_before("create", variant_code=variant_code)
@@ -444,6 +452,7 @@ class ProductVariantCSVUploadView(APIView):
                             stock=(delta_stock - delta_order + delta_return),  # << 여기
                             order_count=delta_order,
                             return_count=delta_return,
+                            channels=["online"],
                         )
                         created.append(ProductVariantSerializer(variant).data)
                 except Exception as e:
@@ -573,6 +582,14 @@ class ProductVariantCSVUploadView(APIView):
                             stock=F("stock") - sales_count,
                         )
                         variant.refresh_from_db()  #
+                        # 채널 태그: offline 추가
+                        if isinstance(variant.channels, list):
+                            if "offline" not in variant.channels:
+                                variant.channels.append("offline")
+                                variant.save(update_fields=["channels"])
+                        else:
+                            variant.channels = ["offline"]
+                            variant.save(update_fields=["channels"])
                         created.append(ProductVariantSerializer(variant).data)
                     else:
                         self._snapshot_before("update", variant=variant)
@@ -583,6 +600,14 @@ class ProductVariantCSVUploadView(APIView):
                             stock=F("stock") - sales_count,
                         )
                         variant.refresh_from_db()
+                        # 채널 태그: offline 추가
+                        if isinstance(variant.channels, list):
+                            if "offline" not in variant.channels:
+                                variant.channels.append("offline")
+                                variant.save(update_fields=["channels"])
+                        else:
+                            variant.channels = ["offline"]
+                            variant.save(update_fields=["channels"])
                         updated.append(ProductVariantSerializer(variant).data)
 
                 except Exception as e:
@@ -792,6 +817,12 @@ class ProductVariantView(APIView):
                 type=openapi.TYPE_STRING,
                 description="상품 카테고리 (부분일치)",
             ),
+            openapi.Parameter(
+                "channel",
+                in_=openapi.IN_QUERY,
+                type=openapi.TYPE_STRING,
+                description="채널 필터 (online/offline)",
+            ),
         ],
         responses={200: ProductVariantSerializer(many=True)},
     )
@@ -949,6 +980,12 @@ class ProductVariantExportView(APIView):
                 "category", in_=openapi.IN_QUERY, type=openapi.TYPE_STRING
             ),
             openapi.Parameter("ordering", openapi.IN_QUERY, type=openapi.TYPE_STRING),
+            openapi.Parameter(
+                "channel",
+                in_=openapi.IN_QUERY,
+                type=openapi.TYPE_STRING,
+                description="채널 필터 (online/offline)",
+            ),
         ],
         responses={200: ProductVariantSerializer(many=True)},
     )


### PR DESCRIPTION
채널 태깅 추가 
- variant에 pos 데이터 소스 online/offline 추적을 위해 channels라는 필드 도입. 
- 엑셀 파일(온라인) process_variant_detail 추가시 channels에 "online"추가
- 엑셀 파일(오라인) process_sales_summary추가시 channels에 "offline"추가
- ProductVariantSerializer에 channels를 read-only 필드로 노출
- Variant 목록/엑스포트 API에 channel = online/offline 필터 추가


온라인 excel추가시
<img width="2352" height="801" alt="image" src="https://github.com/user-attachments/assets/b10bc28c-8d11-4c66-b59d-90fc79c0c3c8" />



오프라인 excel추가시
<img width="2069" height="851" alt="image" src="https://github.com/user-attachments/assets/1f4a20df-e089-4d0c-83e2-fecfde97d016" />
